### PR TITLE
Restrict Branch Merge and Automatically Add PR labels to Pull Requests

### DIFF
--- a/.github/ISSUE_TEMPLATE/FEATURE_REQUEST.md
+++ b/.github/ISSUE_TEMPLATE/FEATURE_REQUEST.md
@@ -6,6 +6,7 @@ labels: 'enhancement'
 
 ---
 
+
 ## 🚀 Feature Request
 
 _A clear and concise description of the feature or improvement you are suggesting._

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,6 +1,1 @@
 blank_issues_enabled: false
-
-contact_links:
-  - name: Report Security Vulnerability
-    url: mailto:srikar@finbox.in
-    about: Please report security vulnerabilities here.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -41,7 +41,6 @@ Share the testing strategy used to ensure the changes work as expected.
 - [ ] Tests for the changes have been added
 - [ ] CHANGELOG Updated
 - [ ] Version number updated
-- [ ] Added PR Labels
 - [ ] Build is successful
 - [ ] Changes do not negatively impact performance
 - [ ] New code follows Google Java/Kotlin Style guidelines

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,7 @@
+documentation:
+  - changed-files:
+      - any-glob-to-any-file: ['.github/*', '**/*.md']
+
+enhancement:
+  - changed-files:
+      - any-glob-to-any-file: ['FinBoxRiskManager/*', 'RiskManager/*', 'RiskManagerTests/*']

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,16 @@
+name: "Pull Request Labeler"
+on:
+  pull_request_target:
+    types:
+      - opened # Add labels when PR is created
+      - synchronize # Add labels when PR receives new commits, which may modify the files in the PR
+      - reopened # Add labels when PR is opened from closed state
+
+jobs:
+  labeler:
+    permissions:
+      contents: read
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/labeler@v5

--- a/.github/workflows/restrict-main.yml
+++ b/.github/workflows/restrict-main.yml
@@ -1,0 +1,16 @@
+name: "Enforce Release or Hotfix Branch Merge"
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  check-branch:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check if PR is from the release or hotfix branch
+        if: github.head_ref != 'release' && github.head_ref != 'hotfix'
+        run: |
+          echo "Only the release or hotfix branch can be merged into main."
+          exit 1

--- a/.github/workflows/restrict-release.yml
+++ b/.github/workflows/restrict-release.yml
@@ -1,0 +1,16 @@
+name: "Enforce Release Branch Merge"
+
+on:
+  pull_request:
+    branches:
+      - release
+
+jobs:
+  check-branch:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check if PR is from the develop branch
+        if: github.head_ref != 'develop'
+        run: |
+          echo "Only the develop branch can be merged into release."
+          exit 1


### PR DESCRIPTION
## Description

- Automatically Add PR labels to Pull Requests
- Restrict Branch Merge to main other than release and hotfix
- Restrict Branch Merge to release other than develop

## JIRA Tickets

Not Required

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Additional Tests

## How Has This Been Tested?

Share the testing strategy used to ensure the changes work as expected.

- [ ] Unit tests
- [ ] Integration tests
- [ ] UI tests
- [ ] Manual testing

**Test Configuration**:

* Physical Device
  - [ ] iPhone 11
  - [ ] iPhone 12 Mini
  - [ ] Simulator

* OS Version:
  - [ ] 18
  - [ ] 17
  - [ ] 16

**Contributor Checklist**
- [ ] A JIRA Task is created
- [ ] Current Branch name starts with JIRA task name
- [ ] Tests for the changes have been added
- [ ] CHANGELOG Updated
- [ ] Version number updated
- [ ] Added PR Labels
- [ ] Build is successful
- [ ] Changes do not negatively impact performance
- [ ] New code follows Google Java/Kotlin Style guidelines
- [ ] Performed a self-review of my code
- [ ] Removed any logs added in debug mode
- [ ] Commented my code, particularly in hard-to-understand areas

